### PR TITLE
Enhance GitHub Actions for wheel building and publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,13 +2,19 @@ name: Wheels
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
-     - main
+      - main
   release:
     types:
       - published
+
+concurrency:
+  group: wheels-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build_sdist:
@@ -16,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-      with:
-        submodules: true
 
     - uses: astral-sh/setup-uv@v7
       with:
@@ -42,18 +46,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-      with:
-        submodules: true
 
     - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+
     - uses: pypa/cibuildwheel@v3.4.1
-      env:
-        CIBW_BUILD: "cp312-*"
-        CIBW_ARCHS_MACOS: x86_64 arm64
-        CIBW_BUILD_FRONTEND: "build[uv]"
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -74,14 +78,14 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      attestations: write
 
     steps:
-    - uses: astral-sh/setup-uv@v7
-
     - uses: actions/download-artifact@v8
       with:
         path: dist
         merge-multiple: true
 
-    - name: Publish to PyPI
-      run: uv publish dist/*
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        attestations: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,17 @@ build-dir = "build/{wheel_tag}"
 wheel.py-api = "cp312"
 
 [tool.cibuildwheel]
+build = "cp312-*"
 build-frontend = "build[uv]"
 build-verbosity = 1
 test-command = "pytest {project}/tests"
 test-requires = ["pytest", "deepdiff"]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.14"


### PR DESCRIPTION
Improve the GitHub Actions workflow by adding QEMU setup for cross-platform builds and updating dependencies in `pyproject.toml` to support multiple architectures. This enhancement streamlines the process of building and publishing wheels.